### PR TITLE
chore: bump CI Python to a support version.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.13.13
+          python-version: 3.13.15
 
       - name: Install Python dependencies
         run: pip install black flake8


### PR DESCRIPTION
* fixes CI, 3.13.13 is no longer available for Github.