### PR TITLE
ci: only run the dev Quay publish from the canonical repo

### DIFF
--- a/.github/workflows/development-build.yml
+++ b/.github/workflows/development-build.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
     quay_dev:
         name: Push Quay (Dev)
+        # Only publish from the canonical repo; forks don't have the Quay secrets.
+        if: github.repository == 'quadsproject/badfish'
         runs-on: ubuntu-latest
         permissions:
             contents: read


### PR DESCRIPTION
Gates the Development Build's `quay_dev` job to this repo so forks skip it instead of failing at the Quay login.

Forks don't have the `QUAY_USERNAME` / `QUAY_API_TOKEN` secrets, so the job dies on the `podman login` step with "inappropriate ioctl for device" and every fork push goes red. With the guard, `quadsproject/badfish` keeps publishing the dev image exactly as before, and forks just skip it.

Closes #554
