### PR TITLE
fix: black-format emulator.py and main.py

### DIFF
--- a/.github/workflows/rpmlint.yml
+++ b/.github/workflows/rpmlint.yml
@@ -48,7 +48,7 @@ jobs:
           dnf -y install make rpmlint rpm-build python3-devel pyproject-rpm-macros \
             python3-setuptools python3-wheel python3-pip python3-build \
             python3-pyyaml python3-aiohttp python3-async-lru python3-rich \
-            python3-pytest python3-pytest-asyncio glibc-langpack-en
+            python3-pytest python3-pytest-asyncio glibc-langpack-en openssl
 
       - name: Build RPM and run rpmlint
         run: |

--- a/rpm/badfish.spec.tpl
+++ b/rpm/badfish.spec.tpl
@@ -18,12 +18,17 @@ Source:         %{url}/releases/download/v%{version}/badfish-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python3-devel
+# Emulator generates a self-signed TLS cert via the openssl CLI for %check.
+BuildRequires:  openssl
 # Test dependencies
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(pytest-asyncio)
 BuildRequires:  python3dist(pyyaml)
 BuildRequires:  python3dist(aiohttp)
 Provides:       badfish = %{version}-%{release}
+# The emulator subcommand (badfish.emulator.run_daemon) shells out to openssl
+# to generate its self-signed TLS cert on first run.
+Requires:       openssl
 
 %description
 %{desc}

--- a/src/badfish/emulator.py
+++ b/src/badfish/emulator.py
@@ -762,7 +762,10 @@ async def _post(_request):
 
     if path.endswith("/Actions/Oem/EID_674_Manager.ExportSystemConfiguration"):
         job_id = _next_job_id(state)
-        state.jobs[job_id] = {"Export": True, "SystemConfiguration": {"ComponentResults": [], "Id": "SystemConfiguration"}}
+        state.jobs[job_id] = {
+            "Export": True,
+            "SystemConfiguration": {"ComponentResults": [], "Id": "SystemConfiguration"},
+        }
         return web.Response(status=202, headers={"Location": f"{MANAGER}/Jobs/{job_id}"})
     if path.endswith("/Actions/Oem/EID_674_Manager.ImportSystemConfiguration"):
         job_id = _next_job_id(state)

--- a/src/badfish/main.py
+++ b/src/badfish/main.py
@@ -183,9 +183,7 @@ class Badfish:
         if len(host_name_split) > 1:
             host_model = host_name_split[-1]
             rack = self.rack if self.rack is not None else host_name_split[1]
-            uloc = self.uloc if self.uloc is not None else (
-                host_name_split[2] if len(host_name_split) > 2 else None
-            )
+            uloc = self.uloc if self.uloc is not None else (host_name_split[2] if len(host_name_split) > 2 else None)
             for val in [rack, uloc]:
                 if val is not None:
                     prefix.append(val)


### PR DESCRIPTION
Black check is failing on development. Fixes both the lint error and the RPM %check failure:

- `src/badfish/emulator.py`: expand the `state.jobs[job_id]` dict literal (was 123 chars, over the 120 limit)
- `src/badfish/main.py`: collapse the parenthesized `uloc` expression to one line
- `rpm/badfish.spec.tpl` + `.github/workflows/rpmlint.yml`: declare `openssl` as a BuildRequires/Requires (and install it in the dnf step) because the emulator subcommand shells out to `openssl` to generate its self-signed TLS cert on first run; without it `%check` fails the 3 emulator tests

Fixes #556
