### PR TITLE
fix(emulator): set member Id so boot-to-mac resolves devices

### DIFF
--- a/src/badfish/emulator.py
+++ b/src/badfish/emulator.py
@@ -290,6 +290,7 @@ def _member(tmpl_key, items, member_id, uri, fill=None):
         return None
     data = _tmpl(tmpl_key)
     data["@odata.id"] = uri
+    data["Id"] = member_id
     if fill:
         fill(data, item)
     return data

--- a/tests/test_emulator.py
+++ b/tests/test_emulator.py
@@ -417,6 +417,12 @@ async def test_emulator_end_to_end(monkeypatch, tmp_path):
 
         await bf.get_power_consumed_watts()
         assert await bf.get_bios_boot_mode() == "Bios"
+
+        # F8: the EthernetInterface member Id is now populated, so boot_to_mac
+        # resolves the MAC to a device and boots to it instead of raising
+        # "MAC Address does not match any of the existing" (device was None
+        # because the template rendered an empty Id).
+        await bf.boot_to_mac("00:5c:52:31:3a:9c")
     finally:
         if bf:
             await bf.delete_session()
@@ -440,6 +446,7 @@ async def test_inventory_collections_and_members(client):
     nic = await (await client.get(f"{SYSTEM}/EthernetInterfaces/NIC.Integrated.1-1-1", headers=headers)).json()
     assert nic["MACAddress"] == "00:5c:52:31:3a:9c"
     assert nic["LinkStatus"] == "Up"
+    assert nic["Id"] == "NIC.Integrated.1-1-1"
 
     # Network adapter inventory the way badfish walks it: the NetworkPorts and
     # NetworkDeviceFunctions collections under each adapter (get_nic_fqdds) and
@@ -474,12 +481,14 @@ async def test_inventory_collections_and_members(client):
     assert procs["Members@odata.count"] == 2
     cpu = await (await client.get(f"{SYSTEM}/Processors/CPU.Socket.1", headers=headers)).json()
     assert cpu["Model"] and cpu["TotalCores"] > 0
+    assert cpu["Id"] == "CPU.Socket.1"
 
     mem = await (await client.get(f"{SYSTEM}/Memory", headers=headers)).json()
     assert mem["Members@odata.count"] == 2
     dimm = await (await client.get(f"{SYSTEM}/Memory/DIMM.Socket.A1", headers=headers)).json()
     assert dimm["CapacityMiB"] == 32768
     assert dimm["Manufacturer"] == "Micron"
+    assert dimm["Id"] == "DIMM.Socket.A1"
 
     assert (await client.get(f"{SYSTEM}/Memory/DIMM.Socket.ZZ", headers=headers)).status == 404
     assert (await client.get(f"{FIRMWARE}/NOPE", headers=headers)).status == 404


### PR DESCRIPTION
Fixes #564

The EthernetInterface template renders an empty `Id`, so badfish's `boot_to_mac` reads `interface.get("Id")` as `None` and raises `MAC Address does not match any of the existing`. This set `Id = member_id` in the emulator's `_member()` so collection members (EthernetInterface, Processor, Memory) carry a real identity and `--boot-to-mac` resolves the device.

Tests
- Added assertions that the EthernetInterface/Processor/Memory member `Id` equals its expected value in `test_inventory_collections_and_members`.
- Extended `test_emulator_end_to_end`: badfish_factory against a live emulator, `boot_to_mac("00:5c:52:31:3a:9c")` now succeeds (fails pre-fix).
- `PYTHONPATH=src python -m pytest tests/test_emulator.py -q` -> 41 passed