### PR TITLE
fix: propagate boot-to failures, join export path, guard init JSON parses

### DIFF
--- a/src/badfish/main.py
+++ b/src/badfish/main.py
@@ -541,7 +541,10 @@ class Badfish:
             raise BadfishException("Failed to communicate with server.")
 
         raw = await response.text("utf-8", "ignore")
-        data = json.loads(raw.strip())
+        try:
+            data = json.loads(raw.strip())
+        except ValueError:
+            raise BadfishException("Error reading response from host.")
         if "Systems" not in data:
             raise BadfishException("Systems resource not found")
 
@@ -551,7 +554,10 @@ class Badfish:
             raise BadfishException("Authorization Error: verify credentials.")
 
         raw = await systems_response.text("utf-8", "ignore")
-        systems_data = json.loads(raw.strip())
+        try:
+            systems_data = json.loads(raw.strip())
+        except ValueError:
+            raise BadfishException("Error reading response from host.")
 
         if systems_data.get("Members"):
             for member in systems_data["Members"]:
@@ -1279,7 +1285,7 @@ class Badfish:
 
         device = await self.get_host_type_boot_device(host_type, _interfaces_path)
 
-        await self.boot_to(device, True)
+        return await self.boot_to(device, True)
 
     async def boot_to_mac(self, mac_address):
         interfaces_endpoints = await self.get_interfaces_endpoints()
@@ -2553,7 +2559,9 @@ class Badfish:
         # Save the exported configuration
         if "SystemConfiguration" in data:
             now = get_now()
-            filename = file_path + now.strftime(f"%Y-%m-%d_%H%M%S_targets_{targets.replace(',', '-')}_export.json")
+            filename = os.path.join(
+                file_path, now.strftime(f"%Y-%m-%d_%H%M%S_targets_{targets.replace(',', '-')}_export.json")
+            )
             with open(filename, "w") as f:
                 f.write(json.dumps(data, indent=4))
             self.logger.info("SCP export completed successfully.")
@@ -3041,9 +3049,11 @@ async def execute_badfish(_host, _args, logger, format_handler=None, console=Non
             badfish.logger.info("Executing actions on host: %s" % _host)
 
         if device:
-            await badfish.boot_to(device)
+            if not await badfish.boot_to(device):
+                result = False
         elif boot_to_type:
-            await badfish.boot_to_type(boot_to_type, interfaces_path)
+            if not await badfish.boot_to_type(boot_to_type, interfaces_path):
+                result = False
         elif boot_to_mac:
             await badfish.boot_to_mac(boot_to_mac)
         elif check_boot:

--- a/tests/test_boot_to.py
+++ b/tests/test_boot_to.py
@@ -1,5 +1,9 @@
-from unittest.mock import patch
+import logging
 
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from badfish.main import Badfish
 from tests.config import (
     BAD_DEVICE_NAME,
     BLANK_RESP,
@@ -159,3 +163,15 @@ class TestBootTo(TestBase):
         # The error path executes L805-806, but error_handler raises BadfishException
         # which gets caught at higher level and logs generic message
         assert "Failed to communicate" in err
+
+
+@pytest.mark.asyncio
+async def test_boot_to_returns_false_on_no_match():
+    """boot_to() must return False (not None) when the device does not match."""
+    logger = MagicMock(spec=logging.Logger)
+    bf = Badfish("test_host", "user", "pass", logger, 1)
+    bf.check_device = AsyncMock(return_value=False)
+
+    result = await bf.boot_to("bad_device")
+
+    assert result is False

--- a/tests/test_boot_to_type.py
+++ b/tests/test_boot_to_type.py
@@ -1,5 +1,9 @@
-from unittest.mock import patch
+import logging
 
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from badfish.main import Badfish
 from tests.config import (
     BLANK_RESP,
     BOOT_MODE_RESP,
@@ -128,3 +132,20 @@ class TestBootTo(TestBase):
         self.set_mock_response(mock_delete, 200, "OK")
         _, err = self.badfish_call()
         assert err == RESPONSE_BOOT_TO_NO_FILE
+
+
+@pytest.mark.asyncio
+async def test_boot_to_type_returns_false_on_no_device(tmp_path):
+    """boot_to_type() must propagate False from boot_to() when no device matches."""
+    logger = MagicMock(spec=logging.Logger)
+    bf = Badfish("test_host", "user", "pass", logger, 1)
+    iface = tmp_path / "idrac_interfaces.yml"
+    iface.write_text("key: value")
+
+    bf.get_host_types_from_yaml = AsyncMock(return_value=["foreman", "director"])
+    bf.get_host_type_boot_device = AsyncMock(return_value=None)
+    bf.boot_to = AsyncMock(return_value=False)
+
+    result = await bf.boot_to_type("foreman", str(iface))
+
+    assert result is False

--- a/tests/test_boot_to_type.py
+++ b/tests/test_boot_to_type.py
@@ -8,6 +8,9 @@ from tests.config import (
     BLANK_RESP,
     BOOT_MODE_RESP,
     BOOT_SEQ_RESP,
+    DEVICE_HDD_1,
+    DEVICE_NIC_2,
+    render_device_dict,
     BOOT_SEQ_RESPONSE_DIRECTOR,
     INIT_RESP,
     INTERFACES_PATH,
@@ -132,6 +135,33 @@ class TestBootTo(TestBase):
         self.set_mock_response(mock_delete, 200, "OK")
         _, err = self.badfish_call()
         assert err == RESPONSE_BOOT_TO_NO_FILE
+
+    @patch("aiohttp.ClientSession.delete")
+    @patch("aiohttp.ClientSession.post")
+    @patch("aiohttp.ClientSession.patch")
+    @patch("aiohttp.ClientSession.get")
+    def test_boot_to_type_no_match(self, mock_get, mock_patch, mock_post, mock_delete):
+        # Boot sequence without the custom type's first device must propagate
+        # the failure so badfish exits nonzero.
+        boot_seq_resp_fmt = BOOT_SEQ_RESP % str(
+            [render_device_dict(0, DEVICE_HDD_1), render_device_dict(1, DEVICE_NIC_2)]
+        )
+        get_resp = [
+            BOOT_MODE_RESP,
+            boot_seq_resp_fmt.replace("'", '"'),
+            BLANK_RESP,
+        ]
+        responses = INIT_RESP + get_resp
+        self.set_mock_response(mock_get, 200, responses)
+        self.set_mock_response(mock_patch, 200, ["OK"])
+        self.set_mock_response(mock_post, 200, ["OK", JOB_OK_RESP])
+        self.set_mock_response(mock_delete, 200, "OK")
+        self.args = ["-i", INTERFACES_PATH, self.option_arg, "custom"]
+        _, err = self.badfish_call(mock_host="host01.example.com")
+        assert err == (
+            "- ERROR    - Device NIC.Integrated.1-2-1 does not match any of the "
+            "available boot devices for host host01.example.com\n"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,7 +1,12 @@
+import logging
 import os
-from unittest.mock import patch
+from collections import defaultdict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from badfish.helpers.exceptions import BadfishException
+from badfish.main import Badfish, execute_badfish
 from tests.config import (
     HOST_LIST_EXTRAS,
     KEYBOARD_INTERRUPT,
@@ -161,3 +166,53 @@ class TestInitialization(TestBase):
         # When Members array is empty or missing, init() catches the exception and logs as WARNING
         assert "- WARNING  - Could not find system resource:" in err
         assert "Systems resource not found" in err or "ComputerSystem's Members array" in err
+
+
+@pytest.mark.asyncio
+async def test_execute_badfish_boot_to_false_sets_result_false():
+    """execute_badfish() must propagate a False return from boot_to() to `result`."""
+    logger = MagicMock(spec=logging.Logger)
+    fake_badfish = MagicMock()
+    fake_badfish.boot_to = AsyncMock(return_value=False)
+    fake_badfish.session_id = None
+    mock_args = defaultdict(lambda: None)
+    mock_args.update({"u": "user", "p": "pass", "retries": 1, "boot_to": "NIC.1"})
+
+    with patch("badfish.main.badfish_factory", new_callable=AsyncMock) as mock_factory:
+        mock_factory.return_value = fake_badfish
+        result = await execute_badfish("test_host", mock_args, logger, None)
+
+    assert result == ("test_host", False)
+    fake_badfish.boot_to.assert_awaited_once_with("NIC.1")
+
+
+@pytest.mark.asyncio
+async def test_find_systems_resource_invalid_root_json_raises_badfish_exception():
+    """Invalid JSON from the root resource must surface as BadfishException, not JSONDecodeError."""
+    logger = MagicMock(spec=logging.Logger)
+    bf = Badfish("test_host", "user", "pass", logger, 1)
+    bf.http_client = MagicMock()
+
+    root_resp = MagicMock()
+    root_resp.text = AsyncMock(return_value="not json {")
+    bf.http_client.get_request = AsyncMock(return_value=root_resp)
+
+    with pytest.raises(BadfishException, match="Error reading response from host."):
+        await bf.find_systems_resource()
+
+
+@pytest.mark.asyncio
+async def test_find_systems_resource_invalid_systems_json_raises_badfish_exception():
+    """Invalid JSON from the Systems resource must surface as BadfishException, not JSONDecodeError."""
+    logger = MagicMock(spec=logging.Logger)
+    bf = Badfish("test_host", "user", "pass", logger, 1)
+    bf.http_client = MagicMock()
+
+    root_resp = MagicMock()
+    root_resp.text = AsyncMock(return_value='{"Systems":{"@odata.id":"/redfish/v1/Systems"}}')
+    sys_resp = MagicMock()
+    sys_resp.text = AsyncMock(return_value="<html>bad</html>")
+    bf.http_client.get_request = AsyncMock(side_effect=[root_resp, sys_resp])
+
+    with pytest.raises(BadfishException, match="Error reading response from host."):
+        await bf.find_systems_resource()

--- a/tests/test_scp.py
+++ b/tests/test_scp.py
@@ -1,7 +1,11 @@
+import json
+import logging
 import os
+import pytest
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from badfish.main import Badfish
 from tests.config import (
     BLANK_RESP,
     INIT_RESP,
@@ -45,6 +49,38 @@ def fixed_datetime():
 def export_dir_check():
     if not os.path.exists("exports"):
         os.makedirs("exports")
+
+
+@pytest.mark.asyncio
+async def test_export_scp_saves_file_inside_target_dir(tmp_path):
+    """The exported file must land INSIDE the given directory (no trailing slash)."""
+    logger = MagicMock(spec=logging.Logger)
+    bf = Badfish("test_host", "user", "pass", logger, 1)
+    bf.http_client = MagicMock()
+
+    config_body = {"SystemConfiguration": {"Settings": {"value": 1}}}
+    job_resp = MagicMock()
+    job_resp.text = AsyncMock(return_value=json.dumps(config_body))
+
+    post_resp = MagicMock()
+    post_resp.status = 202
+    post_resp.headers = {"Location": f"/redfish/v1/Managers/iDRAC.Embedded.1/Jobs/{JOB_ID}"}
+
+    bf.post_request = AsyncMock(return_value=post_resp)
+    bf._extract_job_id_from_response = MagicMock(return_value=JOB_ID)
+    bf.get_request = AsyncMock(return_value=job_resp)
+
+    expected_name = f"{FIXED_BASE_TIME.strftime('%Y-%m-%d_%H%M%S')}_targets_ALL_export.json"
+
+    with patch("badfish.main.asyncio.sleep", new=AsyncMock()), patch(
+        "badfish.main.get_now", return_value=FIXED_BASE_TIME
+    ):
+        result = await bf.export_scp(str(tmp_path), "ALL")
+
+    assert result is True
+    # os.path.join semantics: the file lives under tmp_path, not as a sibling.
+    assert (tmp_path / expected_name).is_file()
+    assert not (tmp_path.parent / expected_name).exists()
 
 
 class TestGetSCPTargets(TestBase):


### PR DESCRIPTION
Fixes #561
Fixes #562
Fixes #563

- boot_to_type returns its boot_to result; execute_badfish folds a False from boot_to/boot_to_type into the exit status.
- export_scp joins the export filename to the target directory via os.path.join.
- find_systems_resource wraps both response JSON parses in the standard BadfishException guard.

Test results: PYTHONPATH=src python -m pytest tests/test_scp.py tests/test_boot_to.py tests/test_boot_to_type.py tests/test_execution.py -q -> 44 passed.

Coverage: added-line coverage is now 100% (codecov/patch green).