### PR TITLE
fix: harden formatted output parsing and check-boot JSON

### DIFF
--- a/src/badfish/helpers/logger.py
+++ b/src/badfish/helpers/logger.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 from io import StringIO
 
@@ -29,12 +30,34 @@ class NoAliasDumper(yaml.SafeDumper):
         return True
 
 
+class BadfishSafeLoader(yaml.SafeLoader):
+    """SafeLoader that keeps YAML timestamps as strings.
+
+    Real iDRAC firmware data carries ReleaseDate values such as
+    ``0000-00-00T00:00:00Z``. PyYAML's default timestamp constructor converts
+    these to ``datetime`` which raises ``ValueError: year 0 is out of range``.
+    Returning the raw scalar keeps the value a string and avoids the crash.
+    """
+
+
+BadfishSafeLoader.add_constructor(
+    "tag:yaml.org,2002:timestamp",
+    lambda loader, node: loader.construct_scalar(node),
+)
+
+
+def _safe_load(message):
+    """YAML load using :class:`BadfishSafeLoader` (timestamps stay strings)."""
+    return yaml.load(message, Loader=BadfishSafeLoader)
+
+
 class BadfishHandler(StreamHandler):
     def __init__(self, format_flag=False):
         StreamHandler.__init__(self)
         self.messages = {}
         self.formatted_msg = []
         self.output_dict = dict()
+        self.structured = {}
         self.host = None
         self.format_flag = format_flag
 
@@ -45,6 +68,12 @@ class BadfishHandler(StreamHandler):
 
         if getattr(record, "is_table", False):
             return
+
+        # Structured records (e.g. check-boot) are preferred over re-parsing
+        # the human log text when generating json/yaml output.
+        obj = getattr(record, "obj", None)
+        if obj is not None:
+            self.structured[record.name] = obj
 
         if record.levelno == INFO and record.msg != "*" * 48:
             if record.name not in self.messages:
@@ -58,11 +87,20 @@ class BadfishHandler(StreamHandler):
         try:
             if self.host:
                 host_name = self.host.strip().split(".")[0]
+                structured = self.structured.get(host_name)
+                if structured is not None:
+                    self.output_dict.update({self.host: structured.copy()})
+                    self.host = None
+                    return
                 # Ensure the message is properly formatted as YAML by wrapping values in quotes
-                message = self.messages[host_name]
+                message = self.messages.get(host_name)
+                if not message:
+                    self.output_dict = {"unsupported_command": True}
+                    self.host = None
+                    return
                 # Try to parse as is first
                 try:
-                    new_dict = yaml.safe_load(message)
+                    new_dict = _safe_load(message)
                 except yaml.YAMLError:
                     # If parsing fails, try to format the value as a quoted string
                     lines = message.strip().split("\n")
@@ -78,15 +116,22 @@ class BadfishHandler(StreamHandler):
                         else:
                             formatted_lines.append(line)
                     formatted_message = "\n".join(formatted_lines)
-                    new_dict = yaml.safe_load(formatted_message)
+                    new_dict = _safe_load(formatted_message)
 
                 self.output_dict.update({self.host: new_dict.copy()})
                 self.host = None
             else:
-                message = self.messages["badfish.helpers.logger"]
+                structured = self.structured.get("badfish.helpers.logger")
+                if structured is not None:
+                    self.output_dict.update(structured.copy())
+                    return
+                message = self.messages.get("badfish.helpers.logger")
+                if not message:
+                    self.output_dict = {"unsupported_command": True}
+                    return
                 # Apply the same formatting logic for non-host messages
                 try:
-                    new_dict = yaml.safe_load(message)
+                    new_dict = _safe_load(message)
                 except yaml.YAMLError:
                     lines = message.strip().split("\n")
                     formatted_lines = []
@@ -100,59 +145,78 @@ class BadfishHandler(StreamHandler):
                         else:
                             formatted_lines.append(line)
                     formatted_message = "\n".join(formatted_lines)
-                    new_dict = yaml.safe_load(formatted_message)
+                    new_dict = _safe_load(formatted_message)
 
                 self.output_dict.update(new_dict.copy())
-        except yaml.YAMLError:
+        except (yaml.YAMLError, ValueError):
             self.output_dict = {"unsupported_command": True}
 
     def diff(self):
-        try:
-            if self.output_dict["error"]:
-                return f"ERROR - {self.output_dict['error_msg']}"
-        except KeyError:
-            host_first, host_second, *_ = self.output_dict.keys()
-            first, second, *_ = self.output_dict.values()
-            diff_dict = {host_first: {}, host_second: {}}
-            for i in first:
-                for j in second:
-                    if (
-                        first[i]["SoftwareId"] == second[j]["SoftwareId"]
-                        and first[i]["Version"] != second[j]["Version"]
-                        and first[i]["SoftwareId"] != 0
-                    ):
-                        diff_dict[host_first].update(
-                            {
-                                i: {
-                                    "Version": first[i]["Version"],
-                                    "Name": first[i]["Name"],
-                                }
-                            }
-                        )
-                        diff_dict[host_second].update(
-                            {
-                                j: {
-                                    "Version": second[j]["Version"],
-                                    "Name": second[j]["Name"],
-                                }
-                            }
-                        )
+        if self.output_dict.get("error"):
+            return f"ERROR - {self.output_dict.get('error_msg')}"
 
-            if diff_dict[host_first] == {}:
-                return "{}"
-            output = ""
-            formatted = json.dumps(diff_dict[host_first], indent=4, sort_keys=False, default=str)
-            len_first = (max(len(line) for line in formatted.splitlines())) + 10
-            output += f"{host_first}:".ljust(len_first)
-            output += f"{host_second}:\n"
-            for i, j in zip(diff_dict[host_first], diff_dict[host_second]):
-                output += f"{i}".ljust(len_first)
-                output += f"{j}\n"
-                output += f"\t- Name: {(diff_dict[host_first][i])['Name']}".ljust(len_first)
-                output += f"\t- Name: {(diff_dict[host_second][j])['Name']}\n"
-                output += f"\t- Version: {(diff_dict[host_first][i])['Version']}".ljust(len_first)
-                output += f"\t- Version: {(diff_dict[host_second][j])['Version']}\n"
-            return output
+        # F4: only compare across exactly two hosts, each a dict of firmware rows.
+        if len(self.output_dict) != 2:
+            return "{}"
+        (host_first, first), (host_second, second) = self.output_dict.items()
+        if not isinstance(first, dict) or not isinstance(second, dict):
+            return "{}"
+
+        diff_dict = {host_first: {}, host_second: {}}
+        pairs = []
+        for i in first:
+            if not isinstance(first[i], dict):
+                continue
+            for j in second:
+                if not isinstance(second[j], dict):
+                    continue
+                # .get() so rows missing SoftwareId/Version/Name don't raise;
+                # skip pairs that cannot be matched by SoftwareId.
+                first_sid = first[i].get("SoftwareId")
+                second_sid = second[j].get("SoftwareId")
+                if first_sid is None or second_sid is None or first_sid != second_sid:
+                    continue
+                if first_sid == 0:
+                    continue
+                # Skip pairs that lack a Version to compare.
+                if first[i].get("Version") is None or second[j].get("Version") is None:
+                    continue
+                # Compare via str() so YAML floats (e.g. 3.57) resolve identically.
+                if str(first[i].get("Version")) == str(second[j].get("Version")):
+                    continue
+                diff_dict[host_first].update(
+                    {
+                        i: {
+                            "Version": first[i].get("Version"),
+                            "Name": first[i].get("Name"),
+                        }
+                    }
+                )
+                diff_dict[host_second].update(
+                    {
+                        j: {
+                            "Version": second[j].get("Version"),
+                            "Name": second[j].get("Name"),
+                        }
+                    }
+                )
+                pairs.append((i, j))
+
+        if diff_dict[host_first] == {}:
+            return "{}"
+        output = ""
+        formatted = json.dumps(diff_dict[host_first], indent=4, sort_keys=False, default=str)
+        len_first = (max(len(line) for line in formatted.splitlines())) + 10
+        output += f"{host_first}:".ljust(len_first)
+        output += f"{host_second}:\n"
+        for i, j in pairs:
+            output += f"{i}".ljust(len_first)
+            output += f"{j}\n"
+            output += f"\t- Name: {(diff_dict[host_first][i])['Name']}".ljust(len_first)
+            output += f"\t- Name: {(diff_dict[host_second][j])['Name']}\n"
+            output += f"\t- Version: {(diff_dict[host_first][i])['Version']}".ljust(len_first)
+            output += f"\t- Version: {(diff_dict[host_second][j])['Version']}\n"
+        return output
 
     def output(self, output_type, host_order=None):
         if output_type == "json":
@@ -257,6 +321,9 @@ class BadfishLogger:
         self.queue_listener.start()
 
         if self.log_file:
+            log_dir = os.path.dirname(self.log_file)
+            if log_dir:
+                os.makedirs(log_dir, exist_ok=True)
             self.file_handler = FileHandler(self.log_file)
             self.file_handler.setFormatter(Formatter(_file_format_str))
             self.file_handler.setLevel(self.log_level)

--- a/src/badfish/main.py
+++ b/src/badfish/main.py
@@ -1353,15 +1353,18 @@ class Badfish:
         if not self.boot_devices:
             await self.get_boot_devices()
 
+        boot_order = {"BootOrder": [device["Name"] for device in sorted(self.boot_devices, key=lambda x: x["Index"])]}
+
         if _interfaces_path:
             _host_type = await self.get_host_type(_interfaces_path)
             if _host_type:
-                self.logger.warning("Current boot order is set to: %s." % _host_type)
+                boot_order["HostType"] = _host_type
+                self.logger.warning("Current boot order is set to: %s." % _host_type, extra={"obj": boot_order})
                 return True
             else:
                 self.logger.warning("Current boot order does not match any of the given.")
 
-        self.logger.info("Current boot order:")
+        self.logger.info("Current boot order:", extra={"obj": boot_order})
         if self._use_tables:
             table = Table(show_header=True, header_style="bold")
             table.add_column("#", justify="right")

--- a/tests/config.py
+++ b/tests/config.py
@@ -418,7 +418,7 @@ FIRMWARE_INVENTORY_1_RESP = (
     "{"
     '"Id": "Installed-0-16.25.40.62",'
     '"Name": "Mellanox ConnectX-5",'
-    '"ReleaseDate": "00:00:00Z",'
+    '"ReleaseDate": "0000-00-00T00:00:00Z",'
     '"SoftwareId": "0",'
     '"Status": {"Health": "OK","State": "Enabled"},'
     '"Updateable": "True",'
@@ -428,7 +428,7 @@ FIRMWARE_INVENTORY_2_RESP = (
     "{"
     '"Id": "Installed-0-19.5.12",'
     '"Name": "Intel(R) Ethernet Network Adapter",'
-    '"ReleaseDate": "00:00:00Z",'
+    '"ReleaseDate": "0000-00-00T00:00:00Z",'
     '"SoftwareId": "0",'
     '"Status": {"Health": "OK","State": "Enabled"},'
     '"Updateable": "True",'
@@ -439,7 +439,7 @@ RESPONSE_FIRMWARE_INVENTORY = (
     "- INFO     - Installed-0-16.25.40.62:\n"
     "- INFO     -     Id: Installed-0-16.25.40.62\n"
     "- INFO     -     Name: Mellanox ConnectX-5\n"
-    "- INFO     -     ReleaseDate: 00:00:00Z\n"
+    "- INFO     -     ReleaseDate: 0000-00-00T00:00:00Z\n"
     "- INFO     -     SoftwareId: 0\n"
     "- INFO     -     Status: {'Health': 'OK', 'State': 'Enabled'}\n"
     "- INFO     -     Updateable: True\n"
@@ -447,7 +447,7 @@ RESPONSE_FIRMWARE_INVENTORY = (
     "- INFO     - Installed-0-19.5.12:\n"
     "- INFO     -     Id: Installed-0-19.5.12\n"
     "- INFO     -     Name: Intel(R) Ethernet Network Adapter\n"
-    "- INFO     -     ReleaseDate: 00:00:00Z\n"
+    "- INFO     -     ReleaseDate: 0000-00-00T00:00:00Z\n"
     "- INFO     -     SoftwareId: 0\n"
     "- INFO     -     Status: {'Health': 'OK', 'State': 'Enabled'}\n"
     "- INFO     -     Updateable: True\n"
@@ -458,7 +458,7 @@ RESPONSE_FIRMWARE_INVENTORY_NONE_RESPONSE = (
     "- INFO     - Installed-0-16.25.40.62:\n"
     "- INFO     -     Id: Installed-0-16.25.40.62\n"
     "- INFO     -     Name: Mellanox ConnectX-5\n"
-    "- INFO     -     ReleaseDate: 00:00:00Z\n"
+    "- INFO     -     ReleaseDate: 0000-00-00T00:00:00Z\n"
     "- INFO     -     SoftwareId: 0\n"
     "- INFO     -     Status: {'Health': 'OK', 'State': 'Enabled'}\n"
     "- INFO     -     Updateable: True\n"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -210,6 +210,53 @@ class TestBadfishHandler:
         }
         assert handler.diff() == "{}"
 
+    def test_parse_with_host_uses_structured_data(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.host = "host1.domain"
+        handler.structured["host1"] = {"BootOrder": ["NIC.Integrated.1-1-1"], "HostType": "foreman"}
+        handler.parse()
+        assert handler.output_dict == {
+            "host1.domain": {"BootOrder": ["NIC.Integrated.1-1-1"], "HostType": "foreman"}
+        }
+
+    def test_parse_with_host_missing_message_sets_error_marker(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.host = "host1.domain"
+        handler.parse()
+        assert handler.output_dict == {"unsupported_command": True}
+
+    def test_diff_tolerates_non_dict_host_values(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.output_dict = {
+            "h1": "not a dict",
+            "h2": {"a": {"SoftwareId": 1, "Version": "1", "Name": "A"}},
+        }
+        assert handler.diff() == "{}"
+
+    def test_diff_skips_non_dict_first_host_rows(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.output_dict = {
+            "h1": {"a": "not a row"},
+            "h2": {"b": {"SoftwareId": 1, "Version": "1", "Name": "B"}},
+        }
+        assert handler.diff() == "{}"
+
+    def test_diff_skips_non_dict_second_host_rows(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.output_dict = {
+            "h1": {"a": {"SoftwareId": 1, "Version": "1", "Name": "A"}},
+            "h2": {"b": "not a row"},
+        }
+        assert handler.diff() == "{}"
+
+    def test_diff_skips_software_id_zero(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.output_dict = {
+            "h1": {"a": {"SoftwareId": 0, "Version": "1", "Name": "A"}},
+            "h2": {"b": {"SoftwareId": 0, "Version": "2", "Name": "B"}},
+        }
+        assert handler.diff() == "{}"
+
     def test_output_json_and_yaml(self):
         handler = BadfishHandler(format_flag=True)
         handler.output_dict = {"a": 1, "b": "x"}

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from logging import INFO, ERROR, DEBUG, LogRecord
+from logging import INFO, ERROR, DEBUG, WARNING, LogRecord
 
 from badfish.helpers.logger import BadfishHandler, BadfishFormatter, BadfishLogger
 import yaml
@@ -94,9 +94,7 @@ class TestBadfishHandler:
         handler = BadfishHandler(format_flag=True)
         handler.host = "hostx"
         handler.messages["hostx"] = "key: value\n"
-        with patch(
-            "badfish.helpers.logger.yaml.safe_load", side_effect=[yaml.YAMLError("bad1"), yaml.YAMLError("bad2")]
-        ):
+        with patch("badfish.helpers.logger._safe_load", side_effect=[yaml.YAMLError("bad1"), yaml.YAMLError("bad2")]):
             handler.parse()
         assert handler.output_dict == {"unsupported_command": True}
 
@@ -104,11 +102,56 @@ class TestBadfishHandler:
         handler = BadfishHandler(format_flag=True)
         # No host set, exercise the else branch
         handler.messages["badfish.helpers.logger"] = "key: value\n"
-        with patch(
-            "badfish.helpers.logger.yaml.safe_load", side_effect=[yaml.YAMLError("bad1"), yaml.YAMLError("bad2")]
-        ):
+        with patch("badfish.helpers.logger._safe_load", side_effect=[yaml.YAMLError("bad1"), yaml.YAMLError("bad2")]):
             handler.parse()
         assert handler.output_dict == {"unsupported_command": True}
+
+    def test_parse_zero_date_release_date_stays_string(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.messages["badfish.helpers.logger"] = (
+            "Installed-0-16.25.40.62:\n"
+            "    Id: Installed-0-16.25.40.62\n"
+            "    Name: Mellanox ConnectX-5\n"
+            "    ReleaseDate: 0000-00-00T00:00:00Z\n"
+            "    SoftwareId: 0\n"
+            "    Version: 16.25.40.62\n"
+        )
+        handler.parse()
+        row = handler.output_dict["Installed-0-16.25.40.62"]
+        assert row["ReleaseDate"] == "0000-00-00T00:00:00Z"
+
+    def test_parse_missing_message_sets_error_marker(self):
+        handler = BadfishHandler(format_flag=True)
+        # No INFO message and no structured data must not raise (F13).
+        handler.parse()
+        assert handler.output_dict == {"unsupported_command": True}
+
+    def test_parse_uses_structured_check_boot_data(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.structured["badfish.helpers.logger"] = {
+            "BootOrder": ["NIC.Integrated.1-1-1"],
+            "HostType": "foreman",
+        }
+        handler.parse()
+        assert handler.output_dict == {"BootOrder": ["NIC.Integrated.1-1-1"], "HostType": "foreman"}
+
+    def test_emit_stores_structured_obj(self):
+        handler = BadfishHandler(format_flag=True)
+        record = LogRecord(
+            name="badfish.helpers.logger",
+            level=WARNING,
+            pathname=__file__,
+            lineno=1,
+            msg="Current boot order is set to: foreman.",
+            args=(),
+            exc_info=None,
+        )
+        record.obj = {"BootOrder": ["NIC.Integrated.1-1-1"], "HostType": "foreman"}
+        handler.emit(record)
+        assert handler.structured["badfish.helpers.logger"] == {
+            "BootOrder": ["NIC.Integrated.1-1-1"],
+            "HostType": "foreman",
+        }
 
     def test_diff_returns_error_if_error_flag_set(self):
         handler = BadfishHandler(format_flag=True)
@@ -136,6 +179,34 @@ class TestBadfishHandler:
         handler.output_dict = {
             "h1": {"a": {"SoftwareId": 1, "Version": "1", "Name": "A"}},
             "h2": {"b": {"SoftwareId": 1, "Version": "1", "Name": "A"}},
+        }
+        assert handler.diff() == "{}"
+
+    def test_diff_tolerates_zero_hosts(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.output_dict = {}
+        assert handler.diff() == "{}"
+
+    def test_diff_tolerates_single_host(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.output_dict = {
+            "h1": {"a": {"SoftwareId": 1, "Version": "1", "Name": "A"}},
+        }
+        assert handler.diff() == "{}"
+
+    def test_diff_tolerates_missing_software_id(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.output_dict = {
+            "h1": {"a": {"Version": "1", "Name": "A"}},
+            "h2": {"b": {"Version": "2", "Name": "B"}},
+        }
+        assert handler.diff() == "{}"
+
+    def test_diff_tolerates_missing_version(self):
+        handler = BadfishHandler(format_flag=True)
+        handler.output_dict = {
+            "h1": {"a": {"SoftwareId": 1, "Name": "A"}},
+            "h2": {"b": {"SoftwareId": 1, "Name": "B"}},
         }
         assert handler.diff() == "{}"
 
@@ -212,6 +283,15 @@ class TestBadfishLogger:
                 os.remove(path)
             except OSError:
                 pass
+
+    def test_logger_creates_missing_log_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = os.path.join(tmp, "sub", "dir", "bad.log")
+            logger = BadfishLogger(verbose=False, multi_host=False, log_file=log_path)
+            try:
+                assert os.path.isdir(os.path.join(tmp, "sub", "dir"))
+            finally:
+                logger.queue_listener.stop()
 
     def test_logger_verbose_and_output_flag_behavior(self):
         logger = BadfishLogger(verbose=True, multi_host=False, output=True)


### PR DESCRIPTION
Fixes #559
Fixes #560
Fixes #565
Fixes #567
Fixes #570

Harden formatted-output parsing and check-boot structured output:
- F3: timestamp-safe YAML loader at all four parse() load sites; zero-date ReleaseDate (0000-00-00T00:00:00Z) stays a string instead of raising ValueError; ValueError added to the outer except (no-traceback safety net).
- F4: defensive diff() tolerates 0/1-host shapes and rows missing SoftwareId/Version, compares Version via str(), avoids zip truncation.
- F9: create parent dir for --log before FileHandler.
- F11/F13: emit structured check-boot data (BootOrder, HostType) and guard parse() against missing messages so -o json/yaml --check-boot is sensible and no longer crashes with a matching host type.

Test results: `PYTHONPATH=src python -m pytest tests/test_logger.py tests/test_firmware_inventory.py tests/test_check_boot.py -q` -> 44 passed.

Coverage: added-line coverage is now 100% (codecov/patch green).