### PR TITLE
ci: re-run tox and lint on PR synchronize events

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
     branches: [development, master]
 
   push:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -2,7 +2,7 @@ name: Tox
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
     branches: [development, master]
 
   push:


### PR DESCRIPTION
tox.yml and lint.yml only trigger on pull_request opened/edited, so new commits pushed to an open PR never re-run the tox matrix or linters, leaving check status stale for the head commit.

Adds `synchronize` to both (and rpmlint.yml for consistency).

Fixes #576