### PR TITLE
fix: iDRAC10 virtual media and OS deployment paths

### DIFF
--- a/src/badfish/main.py
+++ b/src/badfish/main.py
@@ -115,6 +115,8 @@ class Badfish:
         self.session_id = None
         self.token = None
         self.vendor = None
+        self.virtual_media_resource = None
+        self.os_deployment_resource = None
         self.console = _console if _console is not None else Console()
         self._progress_disabled = _progress_disabled
         # Tables are useful only in the same conditions as progress bars: TTY,
@@ -1533,14 +1535,60 @@ class Badfish:
         await self.reboot_server(graceful=False)
         return True
 
-    async def get_virtual_media_config(self):
-        vm_path = "/"
-        if self.vendor == "Supermicro":
-            vm_path += "VM1"
-        else:
-            vm_path += "VirtualMedia"
+    @staticmethod
+    def is_optical_media(_id, media_types=None):
+        """Whether a VirtualMedia member is the virtual optical drive."""
+        if "CD" in str(_id):
+            return True
+        return bool(set(media_types or []) & {"CD", "DVD"})
 
-        _uri = "%s%s%s" % (self.host_uri, self.manager_resource, vm_path)
+    async def find_virtual_media_resource(self):
+        """Resolve the virtual media collection.
+
+        iDRAC10 dropped the collection under the manager resource and only
+        serves it under the system resource.
+        """
+        if self.virtual_media_resource:
+            return self.virtual_media_resource
+
+        if self.vendor == "Supermicro":
+            candidates = ["%s/VM1" % self.manager_resource]
+        else:
+            candidates = [
+                "%s/VirtualMedia" % self.manager_resource,
+                "%s/VirtualMedia" % self.system_resource,
+            ]
+
+        for candidate in candidates:
+            _response = await self.get_request("%s%s" % (self.host_uri, candidate))
+            if _response.status == 200:
+                self.virtual_media_resource = candidate
+                return candidate
+
+        raise BadfishException("Not able to access virtual media resource.")
+
+    async def get_virtual_media_device(self, vm_config):
+        """Resolve the virtual optical media device from a media collection."""
+        for member in vm_config:
+            if self.is_optical_media(member.split("/")[-1]):
+                return member
+
+        for member in vm_config:
+            _response = await self.get_request("%s%s" % (self.host_uri, member))
+            try:
+                raw = await _response.text("utf-8", "ignore")
+                data = json.loads(raw.strip())
+            except ValueError:
+                raise BadfishException("There was something wrong getting values for VirtualMedia")
+            if self.is_optical_media(data.get("Id"), data.get("MediaTypes")):
+                return member
+
+        raise BadfishException("No virtual optical media device found.")
+
+    async def get_virtual_media_config(self):
+        vm_resource = await self.find_virtual_media_resource()
+
+        _uri = "%s%s" % (self.host_uri, vm_resource)
         _response = await self.get_request(_uri)
         try:
             raw = await _response.text("utf-8", "ignore")
@@ -1593,7 +1641,9 @@ class Badfish:
                 self.logger.info(f"    Name: {_data.get('Name')}")
                 self.logger.info(f"    ImageName: {_data.get('ImageName')}")
                 self.logger.info(f"    Inserted: {_data.get('Inserted')}")
-                if str(_data.get("Inserted")).lower() == "true" and "CD" in str(_data.get("Id")):
+                if str(_data.get("Inserted")).lower() == "true" and self.is_optical_media(
+                    _data.get("Id"), _data.get("MediaTypes")
+                ):
                     inserted = True
             except ValueError:
                 raise BadfishException("There was something wrong getting values for VirtualMedia")
@@ -1620,7 +1670,7 @@ class Badfish:
             else:
                 raise BadfishException("There was something wrong trying to mount virtual media.")
         else:
-            vcd = [x for x in vm_config if "CD" in x][0]
+            vcd = await self.get_virtual_media_device(vm_config)
             _uri = "%s%s/Actions/VirtualMedia.InsertMedia" % (self.host_uri, vcd)
             _payload = {"Image": path}
             _response = await self.post_request(_uri, payload=_payload, headers=_headers)
@@ -1654,7 +1704,7 @@ class Badfish:
             _uri = "%s%s" % (self.host_uri, vm_config["config"])
             _response = await self.patch_request(_uri, payload=_payload, headers=_headers)
         else:
-            vcd = [x for x in vm_config if "CD" in x][0]
+            vcd = await self.get_virtual_media_device(vm_config)
             _uri = "%s%s/Actions/VirtualMedia.EjectMedia" % (self.host_uri, vcd)
             _response = await self.post_request(_uri, payload={}, headers=_headers)
             status = _response.status
@@ -1713,11 +1763,31 @@ class Badfish:
                 return False
         return True
 
+    async def find_os_deployment_resource(self):
+        """Resolve the Dell OS deployment service.
+
+        iDRAC10 dropped the legacy /redfish/v1/Dell OEM namespace and serves
+        the service under the system resource instead.
+        """
+        if self.os_deployment_resource:
+            return self.os_deployment_resource
+
+        system_id = self.system_resource.split("/")[-1]
+        candidates = [
+            "%s/Oem/Dell/DellOSDeploymentService" % self.system_resource,
+            "%s/Dell/Systems/%s/DellOSDeploymentService" % (self.redfish_uri, system_id),
+        ]
+
+        for candidate in candidates:
+            _response = await self.get_request("%s%s" % (self.host_uri, candidate))
+            if _response.status == 200:
+                self.os_deployment_resource = candidate
+                return candidate
+
+        return None
+
     async def check_os_deployment_support(self):
-        _uri = "%s/redfish/v1/Dell/Systems/System.Embedded.1/DellOSDeploymentService" % self.host_uri
-        _response = await self.get_request(_uri)
-        await _response.text("utf-8", "ignore")
-        if _response.status != 200:
+        if not await self.find_os_deployment_resource():
             self.logger.error(
                 "iDRAC version installed doesn't support DellOSDeploymentService needed for this feature."
             )
@@ -1727,10 +1797,7 @@ class Badfish:
     async def check_remote_image(self):
         if not await self.check_os_deployment_support():
             return False
-        _uri = (
-            "%s/redfish/v1/Dell/Systems/System.Embedded.1/DellOSDeploymentService/Actions/DellOSDeploymentService."
-            "GetAttachStatus" % self.host_uri
-        )
+        _uri = "%s%s/Actions/DellOSDeploymentService.GetAttachStatus" % (self.host_uri, self.os_deployment_resource)
         _headers = {"Content-Type": "application/json"}
         _response = await self.post_request(_uri, payload={}, headers=_headers)
         try:
@@ -1749,10 +1816,7 @@ class Badfish:
     async def boot_remote_image(self, nfs_path):
         if not await self.check_os_deployment_support():
             return False
-        _uri = (
-            "%s/redfish/v1/Dell/Systems/System.Embedded.1/DellOSDeploymentService/Actions/DellOSDeploymentService"
-            ".BootToNetworkISO" % self.host_uri
-        )
+        _uri = "%s%s/Actions/DellOSDeploymentService.BootToNetworkISO" % (self.host_uri, self.os_deployment_resource)
         _headers = {"Content-Type": "application/json"}
         try:
             split_path = str(nfs_path).split(":")
@@ -1791,10 +1855,7 @@ class Badfish:
     async def detach_remote_image(self):
         if not await self.check_os_deployment_support():
             return False
-        _uri = (
-            "%s/redfish/v1/Dell/Systems/System.Embedded.1/DellOSDeploymentService/Actions/DellOSDeploymentService"
-            ".DetachISOImage" % self.host_uri
-        )
+        _uri = "%s%s/Actions/DellOSDeploymentService.DetachISOImage" % (self.host_uri, self.os_deployment_resource)
         _headers = {"Content-Type": "application/json"}
         _response = await self.post_request(_uri, payload={}, headers=_headers)
         if _response.status == 200:

--- a/tests/test_badfish_idrac10.py
+++ b/tests/test_badfish_idrac10.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from badfish.main import Badfish
+from badfish.helpers.exceptions import BadfishException
+
+HOST_URI = "https://mgmt-host.example.com"
+REDFISH_URI = "/redfish/v1"
+SYSTEM_RESOURCE = "/redfish/v1/Systems/System.Embedded.1"
+MANAGER_RESOURCE = "/redfish/v1/Managers/iDRAC.Embedded.1"
+MANAGER_VM = "%s/VirtualMedia" % MANAGER_RESOURCE
+SYSTEM_VM = "%s/VirtualMedia" % SYSTEM_RESOURCE
+MEMBER_CD = "%s/CD" % MANAGER_VM
+MEMBER_REMOVABLE = "%s/RemovableDisk" % MANAGER_VM
+MEMBER_ONE = "%s/1" % SYSTEM_VM
+MEMBER_TWO = "%s/2" % SYSTEM_VM
+OEM_OSD = "%s/Oem/Dell/DellOSDeploymentService" % SYSTEM_RESOURCE
+LEGACY_OSD = "%s/Dell/Systems/System.Embedded.1/DellOSDeploymentService" % REDFISH_URI
+OPTICAL_MEDIA_TYPES = ["CD", "DVD", "USBStick"]
+
+
+def url(path):
+    return "%s%s" % (HOST_URI, path)
+
+
+def make_response(status=200, payload=None):
+    response = MagicMock()
+    response.status = status
+    response.headers = {}
+    response.text = AsyncMock(return_value=json.dumps(payload if payload is not None else {}))
+    return response
+
+
+def router(responses, default_status=404):
+    """Return a side effect resolving request URIs against a response map."""
+
+    def _resolve(uri, *args, **kwargs):
+        if uri in responses:
+            return responses[uri]
+        return make_response(default_status, {"error": {"code": "Base.1.18.GeneralError"}})
+
+    return _resolve
+
+
+def media_collection(*members):
+    return {"Members": [{"@odata.id": member} for member in members]}
+
+
+@pytest.fixture
+def badfish_instance():
+    badfish = Badfish("mgmt-host.example.com", "r1", "u1", MagicMock(), 3, _loop=MagicMock())
+    badfish.system_resource = SYSTEM_RESOURCE
+    badfish.manager_resource = MANAGER_RESOURCE
+    badfish.vendor = "Dell"
+    return badfish
+
+
+class TestIsOpticalMedia:
+    def test_matches_by_id(self):
+        assert Badfish.is_optical_media("CD") is True
+
+    def test_ignores_removable_disk(self):
+        assert Badfish.is_optical_media("RemovableDisk") is False
+
+    def test_matches_by_media_types(self):
+        assert Badfish.is_optical_media("1", OPTICAL_MEDIA_TYPES) is True
+
+    def test_ignores_usb_only_media_types(self):
+        assert Badfish.is_optical_media("2", ["USBStick"]) is False
+
+    def test_ignores_numeric_id_without_media_types(self):
+        assert Badfish.is_optical_media("1") is False
+
+
+class TestFindVirtualMediaResource:
+    @pytest.mark.asyncio
+    async def test_manager_resource(self, badfish_instance):
+        badfish_instance.get_request = AsyncMock(side_effect=router({url(MANAGER_VM): make_response()}))
+
+        assert await badfish_instance.find_virtual_media_resource() == MANAGER_VM
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_system_resource(self, badfish_instance):
+        badfish_instance.get_request = AsyncMock(side_effect=router({url(SYSTEM_VM): make_response()}))
+
+        assert await badfish_instance.find_virtual_media_resource() == SYSTEM_VM
+
+    @pytest.mark.asyncio
+    async def test_supermicro_resource(self, badfish_instance):
+        badfish_instance.vendor = "Supermicro"
+        vm1 = "%s/VM1" % MANAGER_RESOURCE
+        badfish_instance.get_request = AsyncMock(side_effect=router({url(vm1): make_response()}))
+
+        assert await badfish_instance.find_virtual_media_resource() == vm1
+
+    @pytest.mark.asyncio
+    async def test_cached_resource(self, badfish_instance):
+        badfish_instance.virtual_media_resource = SYSTEM_VM
+        badfish_instance.get_request = AsyncMock()
+
+        assert await badfish_instance.find_virtual_media_resource() == SYSTEM_VM
+        badfish_instance.get_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_resource_found(self, badfish_instance):
+        badfish_instance.get_request = AsyncMock(side_effect=router({}))
+
+        with pytest.raises(BadfishException):
+            await badfish_instance.find_virtual_media_resource()
+
+
+class TestGetVirtualMediaDevice:
+    @pytest.mark.asyncio
+    async def test_device_by_name(self, badfish_instance):
+        badfish_instance.get_request = AsyncMock()
+
+        assert await badfish_instance.get_virtual_media_device([MEMBER_REMOVABLE, MEMBER_CD]) == MEMBER_CD
+        badfish_instance.get_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_device_by_media_types(self, badfish_instance):
+        member_data = make_response(payload={"Id": "1", "MediaTypes": OPTICAL_MEDIA_TYPES})
+        badfish_instance.get_request = AsyncMock(side_effect=router({url(MEMBER_ONE): member_data}))
+
+        assert await badfish_instance.get_virtual_media_device([MEMBER_ONE, MEMBER_TWO]) == MEMBER_ONE
+
+    @pytest.mark.asyncio
+    async def test_no_optical_device(self, badfish_instance):
+        member_data = make_response(payload={"Id": "1", "MediaTypes": ["USBStick"]})
+        badfish_instance.get_request = AsyncMock(side_effect=router({url(MEMBER_ONE): member_data}))
+
+        with pytest.raises(BadfishException):
+            await badfish_instance.get_virtual_media_device([MEMBER_ONE])
+
+    @pytest.mark.asyncio
+    async def test_device_invalid_json_raises(self, badfish_instance):
+        member_data = make_response(payload={"Id": "1", "MediaTypes": ["USBStick"]})
+        member_data.text = AsyncMock(return_value="{not json")
+        badfish_instance.get_request = AsyncMock(side_effect=router({url(MEMBER_ONE): member_data}))
+
+        with pytest.raises(BadfishException):
+            await badfish_instance.get_virtual_media_device([MEMBER_ONE])
+
+
+class TestVirtualMediaActions:
+    @pytest.mark.asyncio
+    async def test_check_virtual_media_numeric_ids(self, badfish_instance):
+        badfish_instance.virtual_media_resource = SYSTEM_VM
+        responses = {
+            url(SYSTEM_VM): make_response(payload=media_collection(MEMBER_ONE, MEMBER_TWO)),
+            url(MEMBER_ONE): make_response(payload={"Id": "1", "Inserted": True, "MediaTypes": OPTICAL_MEDIA_TYPES}),
+            url(MEMBER_TWO): make_response(payload={"Id": "2", "Inserted": False, "MediaTypes": OPTICAL_MEDIA_TYPES}),
+        }
+        badfish_instance.get_request = AsyncMock(side_effect=router(responses))
+
+        assert await badfish_instance.check_virtual_media() is True
+
+    @pytest.mark.asyncio
+    async def test_unmount_virtual_media_numeric_ids(self, badfish_instance):
+        badfish_instance.virtual_media_resource = SYSTEM_VM
+        responses = {
+            url(SYSTEM_VM): make_response(payload=media_collection(MEMBER_ONE, MEMBER_TWO)),
+            url(MEMBER_ONE): make_response(payload={"Id": "1", "MediaTypes": OPTICAL_MEDIA_TYPES}),
+        }
+        badfish_instance.get_request = AsyncMock(side_effect=router(responses))
+        badfish_instance.post_request = AsyncMock(return_value=make_response(status=204))
+
+        assert await badfish_instance.unmount_virtual_media() is True
+        assert badfish_instance.post_request.call_args[0][0] == url("%s/Actions/VirtualMedia.EjectMedia" % MEMBER_ONE)
+
+    @pytest.mark.asyncio
+    async def test_mount_virtual_media_numeric_ids(self, badfish_instance):
+        badfish_instance.virtual_media_resource = SYSTEM_VM
+        responses = {
+            url(SYSTEM_VM): make_response(payload=media_collection(MEMBER_ONE, MEMBER_TWO)),
+            url(MEMBER_ONE): make_response(payload={"Id": "1", "MediaTypes": OPTICAL_MEDIA_TYPES}),
+        }
+        badfish_instance.get_request = AsyncMock(side_effect=router(responses))
+        badfish_instance.post_request = AsyncMock(return_value=make_response(status=204))
+
+        assert await badfish_instance.mount_virtual_media("http://example.com/boot.iso") is True
+        assert badfish_instance.post_request.call_args[0][0] == url("%s/Actions/VirtualMedia.InsertMedia" % MEMBER_ONE)
+
+
+class TestOsDeploymentResource:
+    @pytest.mark.asyncio
+    async def test_oem_resource(self, badfish_instance):
+        badfish_instance.get_request = AsyncMock(side_effect=router({url(OEM_OSD): make_response()}))
+
+        assert await badfish_instance.find_os_deployment_resource() == OEM_OSD
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_legacy_resource(self, badfish_instance):
+        badfish_instance.get_request = AsyncMock(side_effect=router({url(LEGACY_OSD): make_response()}))
+
+        assert await badfish_instance.find_os_deployment_resource() == LEGACY_OSD
+
+    @pytest.mark.asyncio
+    async def test_resources_follow_discovered_system_id(self, badfish_instance):
+        badfish_instance.system_resource = "/redfish/v1/Systems/System.Embedded.2"
+        legacy = "%s/Dell/Systems/System.Embedded.2/DellOSDeploymentService" % REDFISH_URI
+        badfish_instance.get_request = AsyncMock(side_effect=router({url(legacy): make_response()}))
+
+        assert await badfish_instance.find_os_deployment_resource() == legacy
+
+    @pytest.mark.asyncio
+    async def test_cached_resource(self, badfish_instance):
+        badfish_instance.os_deployment_resource = OEM_OSD
+        badfish_instance.get_request = AsyncMock()
+
+        assert await badfish_instance.find_os_deployment_resource() == OEM_OSD
+        badfish_instance.get_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unsupported_resource(self, badfish_instance):
+        badfish_instance.get_request = AsyncMock(side_effect=router({}))
+
+        assert await badfish_instance.find_os_deployment_resource() is None
+        assert await badfish_instance.check_os_deployment_support() is False
+
+    @pytest.mark.asyncio
+    async def test_detach_remote_image_uses_resolved_resource(self, badfish_instance):
+        badfish_instance.get_request = AsyncMock(side_effect=router({url(OEM_OSD): make_response()}))
+        badfish_instance.post_request = AsyncMock(return_value=make_response())
+
+        assert await badfish_instance.detach_remote_image() is True
+        expected = url("%s/Actions/DellOSDeploymentService.DetachISOImage" % OEM_OSD)
+        assert badfish_instance.post_request.call_args[0][0] == expected
+
+    @pytest.mark.asyncio
+    async def test_check_remote_image_uses_resolved_resource(self, badfish_instance):
+        badfish_instance.get_request = AsyncMock(side_effect=router({url(OEM_OSD): make_response()}))
+        badfish_instance.post_request = AsyncMock(return_value=make_response(payload={"ISOAttachStatus": "Attached"}))
+
+        assert await badfish_instance.check_remote_image() is True
+        expected = url("%s/Actions/DellOSDeploymentService.GetAttachStatus" % OEM_OSD)
+        assert badfish_instance.post_request.call_args[0][0] == expected
+
+    @pytest.mark.asyncio
+    async def test_boot_remote_image_uses_resolved_resource(self, badfish_instance):
+        task = "%s/TaskService/Tasks/JID_123" % REDFISH_URI
+        responses = {
+            url(OEM_OSD): make_response(),
+            url(task): make_response(payload={"TaskStatus": "OK"}),
+        }
+        badfish_instance.get_request = AsyncMock(side_effect=router(responses))
+        boot_response = make_response(status=202)
+        boot_response.headers = {"Location": task}
+        badfish_instance.post_request = AsyncMock(return_value=boot_response)
+
+        assert await badfish_instance.boot_remote_image("server:/path/to.iso") is True
+        expected = url("%s/Actions/DellOSDeploymentService.BootToNetworkISO" % OEM_OSD)
+        assert badfish_instance.post_request.call_args[0][0] == expected

--- a/tests/test_virtual_media.py
+++ b/tests/test_virtual_media.py
@@ -529,7 +529,7 @@ class TestBootRemoteImage(TestBase):
     @patch("aiohttp.ClientSession.post")
     @patch("aiohttp.ClientSession.get")
     def test_boot_good(self, mock_get, mock_post, mock_delete):
-        responses_get = [BLANK_RESP, VMEDIA_REMOTE_BOOT_TASK_RESP]
+        responses_get = [VMEDIA_REMOTE_BOOT_TASK_RESP]
         responses = INIT_RESP + responses_get
         self.set_mock_response(mock_get, 200, responses)
         self.set_mock_response(mock_post, [200, 202], "OK", True)
@@ -568,7 +568,7 @@ class TestBootRemoteImage(TestBase):
     @patch("aiohttp.ClientSession.post")
     @patch("aiohttp.ClientSession.get")
     def test_boot_task_fail(self, mock_get, mock_post, mock_delete):
-        responses_get = [BLANK_RESP, VMEDIA_REMOTE_BOOT_TASK_FAILED_RESP]
+        responses_get = [VMEDIA_REMOTE_BOOT_TASK_FAILED_RESP]
         responses = INIT_RESP + responses_get
         self.set_mock_response(mock_get, 200, responses)
         self.set_mock_response(mock_post, [200, 202], "OK", True)


### PR DESCRIPTION
Ports the iDRAC10 fix from [quadsproject/quads#723](https://github.com/quadsproject/quads/issues/723) (commit 0dd27bb4, change 1248879).

Dell 17G hosts (R670, iDRAC10) fail virtual media cleanup and OS deployment with "Could not unmount virtual media" and "iDRAC version installed doesn't support DellOSDeploymentService". iDRAC10 dropped the legacy `/redfish/v1/Dell` OEM namespace and no longer serves the VirtualMedia collection under the manager resource.

Changes:
- `find_virtual_media_resource()` resolves the VirtualMedia collection from the manager then system resource, caching the result. Supermicro keeps the single `{manager}/VM1` candidate.
- `is_optical_media()` and `get_virtual_media_device()` replace the `[x for x in vm_config if "CD" in x][0]` filter used by mount/unmount; a miss raises `BadfishException` instead of `IndexError`.
- `check_virtual_media()` uses the same predicate.
- `find_os_deployment_resource()` tries `{system}/Oem/Dell/DellOSDeploymentService` then the legacy `/redfish/v1/Dell` path, caching the result. `check_os_deployment_support`, `check_remote_image`, `boot_remote_image` and `detach_remote_image` now build their action URIs from the resolved resource.

New tests in `tests/test_badfish_idrac10.py` (25 tests): predicate, both resolvers (iDRAC9 path, iDRAC10 fallback, Supermicro, caching, discovered system id, not found), device selection by name and MediaTypes, and mount, unmount, check, detach, attach status against iDRAC10 style numeric members.

Verified: full suite 435 passed; black and flake8 (CI args) clean on `src/`.

fixes: https://github.com/quadsproject/badfish/issues/578