### PR TITLE
fix: retry quay pulls to handle transient CDN EOFs

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -136,10 +136,11 @@ jobs:
             - name: Build and Push
               run: |
                   # Added --no-cache to ensure fresh layers
-                  podman build --no-cache -t quay.io/quads/badfish:master .
+                  # Retry pulls/pushes to ride out transient Quay CDN EOFs
+                  podman build --no-cache --retry=5 --retry-delay=15s -t quay.io/quads/badfish:master .
                   podman tag quay.io/quads/badfish:master quay.io/quads/badfish:latest
-                  podman push quay.io/quads/badfish:master
-                  podman push quay.io/quads/badfish:latest
+                  podman push --retry=5 --retry-delay=15s quay.io/quads/badfish:master
+                  podman push --retry=5 --retry-delay=15s quay.io/quads/badfish:latest
 
     # ------------------------------------------------------------------
     # JOB 4: AUR PUBLISH


### PR DESCRIPTION
Fixes #582

## Problem

The Production Release workflow failed on the quay push job with:

```
writing blob: ... unexpected EOF (while reconnecting: Get
"https://cdn01.quay.io/quayio-production-s3/sha256/12/129d04571684...": EOF)
```

while `podman build` pulled `quay.io/fedora/python-310:latest` from the Quay CDN. Transient CDN connection drop: the same blob pulls cleanly, and only the container push job failed (release tag, PyPI, COPR all succeeded).

## Change

Add `--retry=5 --retry-delay=15s` to `podman build` and `podman push` in the production release workflow. Default retry is 3 with ~2s backoff, which was exhausted before the CDN recovered; spaced retries ride out the hiccup.

```diff
- podman build --no-cache -t quay.io/quads/badfish:master .
+ podman build --no-cache --retry=5 --retry-delay=15s -t quay.io/quads/badfish:master .
...
```

## Verification

- `man podman-build`: `--retry` = times to retry pulling/pushing images on failure (default 3), `--retry-delay` = fixed delay between attempts.
- `podman build --retry=2 --retry-delay=1s` executed successfully against a scratch build.
- YAML validated.

## Note

`development-build.yml` has the same build step with the same exposure; follow-up if wanted.