### PR TITLE
fix: retry init requests and guard JSON parsing

### DIFF
--- a/src/badfish/helpers/http_client.py
+++ b/src/badfish/helpers/http_client.py
@@ -9,6 +9,14 @@ from async_lru import alru_cache
 from badfish.helpers.exceptions import BadfishException
 
 
+def load_json(raw: str, context: str = "response") -> Any:
+    """Parse a JSON response, raising BadfishException on malformed input."""
+    try:
+        return json.loads(raw.strip())
+    except (ValueError, TypeError) as ex:
+        raise BadfishException(f"Error reading {context} from host.") from ex
+
+
 class HTTPClient:
 
     def __init__(
@@ -95,38 +103,46 @@ class HTTPClient:
             return None
 
     async def get_raw(self, uri: str, _continue: bool = False, _get_token: bool = False):
-        try:
-            async with self.semaphore:
-                async with aiohttp.ClientSession() as session:
-                    if not _get_token:
-                        async with session.get(
-                            uri,
-                            headers={"X-Auth-Token": self.token} if self.token else {},
-                            ssl=False if self.insecure else True,
-                            timeout=self.timeout,
-                        ) as _response:
-                            await _response.read()
-                    else:
-                        async with session.get(
-                            uri,
-                            auth=aiohttp.BasicAuth(self.username, self.password),
-                            ssl=False if self.insecure else True,
-                            timeout=self.timeout,
-                        ) as _response:
-                            await _response.read()
-        except (ssl.SSLError, aiohttp.ClientConnectorCertificateError, aiohttp.ClientSSLError) as ex:
-            if _continue:
-                return
-            self._handle_ssl_error(ex)
-        except (Exception, TimeoutError) as ex:
-            if _continue:
-                return
-            else:
+        for _attempt in range(self.retries):
+            try:
+                async with self.semaphore:
+                    async with aiohttp.ClientSession() as session:
+                        if not _get_token:
+                            async with session.get(
+                                uri,
+                                headers={"X-Auth-Token": self.token} if self.token else {},
+                                ssl=False if self.insecure else True,
+                                timeout=self.timeout,
+                            ) as _response:
+                                await _response.read()
+                        else:
+                            async with session.get(
+                                uri,
+                                auth=aiohttp.BasicAuth(self.username, self.password),
+                                ssl=False if self.insecure else True,
+                                timeout=self.timeout,
+                            ) as _response:
+                                await _response.read()
+                return _response
+            except (ssl.SSLError, aiohttp.ClientConnectorCertificateError, aiohttp.ClientSSLError) as ex:
+                if _continue:
+                    return
+                self._handle_ssl_error(ex)
+            except (aiohttp.ClientError, TimeoutError, OSError) as ex:
+                self.logger.debug(f"HTTPClient get_raw attempt {_attempt + 1}/{self.retries} failed: {ex}")
+                if _continue:
+                    return
+                if _attempt < self.retries - 1:
+                    await asyncio.sleep(1)
+            except Exception as ex:
+                if _continue:
+                    return
                 self.logger.debug(f"HTTPClient get_raw exception: {ex}")
                 self.logger.debug(f"Exception type: {type(ex)}")
                 raise BadfishException("Failed to communicate with server.")
-
-        return _response
+        if _continue:
+            return
+        raise BadfishException("Failed to communicate with server.")
 
     async def post_request(
         self,
@@ -214,7 +230,7 @@ class HTTPClient:
             raise BadfishException(f"Failed to communicate with {self.host}")
 
         raw = await _response.text("utf-8", "ignore")
-        data = json.loads(raw.strip())
+        data = load_json(raw)
 
         redfish_version = int(data["RedfishVersion"].replace(".", ""))
         session_uri = None

--- a/src/badfish/main.py
+++ b/src/badfish/main.py
@@ -21,7 +21,7 @@ from badfish.config import TIMEOUT
 from badfish.helpers import get_now
 from badfish.helpers.parser import parse_arguments
 from badfish.helpers.logger import BadfishLogger
-from badfish.helpers.http_client import HTTPClient
+from badfish.helpers.http_client import HTTPClient, load_json
 from badfish.helpers.exceptions import BadfishException
 from badfish.helpers.progress import polling_progress
 
@@ -364,7 +364,7 @@ class Badfish:
                 raise BadfishException("Boot order modification is not supported by this host.")
 
             raw = await _response.text("utf-8", "ignore")
-            data = json.loads(raw.strip())
+            data = load_json(raw, "boot order")
             if "Attributes" in data:
                 try:
                     self.boot_devices = data["Attributes"][_boot_seq]
@@ -403,7 +403,7 @@ class Badfish:
         reset_types = []
         if _response:
             raw = await _response.text("utf-8", "ignore")
-            data = json.loads(raw.strip())
+            data = load_json(raw, "reset types")
             if "Actions" not in data:
                 self.logger.warning("Actions resource not found")
             else:
@@ -469,7 +469,7 @@ class Badfish:
             raise BadfishException(f"Failed to authenticate. Verify your credentials for {self.host}")
 
         raw = await response.text("utf-8", "ignore")
-        data = json.loads(raw.strip())
+        data = load_json(raw, "session")
         try:
             redfish_version = int(data["RedfishVersion"].replace(".", ""))
         except KeyError:
@@ -575,7 +575,7 @@ class Badfish:
             raise BadfishException("Failed to communicate with server.")
 
         raw = await response.text("utf-8", "ignore")
-        data = json.loads(raw.strip())
+        data = load_json(raw, "managers")
         oem = data.get("Oem") or {}
         if "Dell" in oem:
             self.vendor = "Dell"
@@ -594,7 +594,7 @@ class Badfish:
         managers_data = None
         if managers_response:
             raw = await managers_response.text("utf-8", "ignore")
-            managers_data = json.loads(raw.strip())
+            managers_data = load_json(raw, "managers")
         if managers_data and managers_data.get("Members"):
             for member in managers_data["Members"]:
                 managers_service = member["@odata.id"]
@@ -647,7 +647,7 @@ class Badfish:
         status = _response.status
         if status == 200:
             raw = await _response.text("utf-8", "ignore")
-            data = json.loads(raw.strip())
+            data = load_json(raw, "power state")
         else:
             raise BadfishException("Couldn't get power state.")
 
@@ -917,7 +917,7 @@ class Badfish:
         if _response:
             status_code = _response.status
             raw = await _response.text("utf-8", "ignore")
-            data = json.loads(raw.strip())
+            data = load_json(raw, "job status")
 
             if status_code == 200:
                 await asyncio.sleep(10)
@@ -947,7 +947,7 @@ class Badfish:
 
                 status_code = _response.status
                 raw = await _response.text("utf-8", "ignore")
-                data = json.loads(raw.strip())
+                data = load_json(raw, "job status")
                 if status_code != 200:
                     self.logger.error(f"Command failed to check job status, return code is {status_code}")
                     self.logger.debug(f"Extended Info Message: {data}")
@@ -1483,7 +1483,7 @@ class Badfish:
                 continue
 
             raw = await _response.text("utf-8", "ignore")
-            data = json.loads(raw.strip())
+            data = load_json(raw, "firmware inventory")
             row = {k: v for k, v in data.items() if not any(s in k for s in _SKIP)}
             rows.append(row)
 
@@ -2603,7 +2603,7 @@ class Badfish:
         uri = "%s%s/Jobs/%s" % (self.host_uri, self.manager_resource, job_id)
         response = await self.get_request(uri)
         raw = await response.text("utf-8", "ignore")
-        data = json.loads(raw.strip())
+        data = load_json(raw, "export job")
 
         # Check if job failed
         if data.get("JobState") in ["Failed", "CompletedWithErrors"]:
@@ -2618,7 +2618,7 @@ class Badfish:
             uri = "%s/redfish/v1/TaskService/Tasks/%s" % (self.host_uri, job_id)
             response = await self.get_request(uri)
             raw = await response.text("utf-8", "ignore")
-            data = json.loads(raw.strip())
+            data = load_json(raw, "export job")
 
         # Save the exported configuration
         if "SystemConfiguration" in data:
@@ -2670,7 +2670,7 @@ class Badfish:
             uri = "%s/redfish/v1/TaskService/Tasks/%s" % (self.host_uri, job_id)
             response = await self.get_request(uri)
             raw = await response.text("utf-8", "ignore")
-            data = json.loads(raw.strip())
+            data = load_json(raw, "import job")
             if response.status in [200, 202]:
                 await asyncio.sleep(1)
             else:

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import aiohttp
 import pytest
 
-from badfish.helpers.http_client import HTTPClient
+from badfish.helpers.http_client import HTTPClient, load_json
 from badfish.helpers.exceptions import BadfishException
 
 
@@ -115,6 +115,46 @@ async def test_get_raw_exception_raises(mock_get):
     with pytest.raises(BadfishException):
         await client.get_raw("https://x")
     assert any("Failed to communicate" not in m for m in logger.debug_msgs)  # debug captured
+
+
+@pytest.mark.asyncio
+async def test_get_raw_retries_then_succeeds():
+    logger = DummyLogger()
+    client = HTTPClient("host", "u", "p", logger, insecure=False, retries=3)
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        set_mock_response(mock_get, 200, "{}")
+        real_return = mock_get.return_value
+        calls = {"n": 0}
+
+        def transient(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise aiohttp.ClientConnectionError("transient failure")
+            return real_return
+
+        mock_get.side_effect = transient
+        resp = await client.get_raw("https://x")
+        assert resp.status == 200
+        assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+@patch("aiohttp.ClientSession.get", side_effect=aiohttp.ClientConnectionError("down"))
+async def test_get_raw_retries_exhausted_raises(mock_get):
+    logger = DummyLogger()
+    client = HTTPClient("host", "u", "p", logger, insecure=False, retries=3)
+    with pytest.raises(BadfishException):
+        await client.get_raw("https://x")
+    assert mock_get.call_count == 3
+
+
+def test_load_json_valid_returns_parsed():
+    assert load_json('{"a": 1}') == {"a": 1}
+
+
+def test_load_json_raises_on_invalid_json():
+    with pytest.raises(BadfishException, match="Error reading response from host."):
+        load_json("not-json")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #569

## Summary

Two robustness issues in the init/read-only path:

1. **`--retries` never covered init requests.** `HTTPClient` stored `self.retries` but `get_raw` performed a single `session.get` with no retry loop, so transient failures during the initial requests (session discovery, authentication, resource enumeration) failed immediately instead of retrying.

2. **`json.loads` sites lacked `ValueError` handling.** A malformed response surfaced as a raw `ValueError` traceback instead of a clear `BadfishException`.

## Changes

### `src/badfish/helpers/http_client.py`
- `get_raw` now wraps the `session.get`+read in a retry loop honoring `self.retries`:
  - Retries on transient failures (`aiohttp.ClientError`, `TimeoutError`, `OSError`) with a 1s pause between attempts.
  - Non-retryable: SSL certificate errors stay on the existing `_handle_ssl_error` path.
  - `_continue=True` still returns `None` on failure; final failure raises `BadfishException("Failed to communicate with server.")`.
  - `post_request` / `patch_request` / `delete_request` semantics unchanged.
- Added `load_json(raw, context="response")` helper that raises `BadfishException("Error reading <context> from host.")` on `ValueError`/`TypeError`.
- Wrapped the unguarded `json.loads` in `find_session_uri`.

### `src/badfish/main.py`
- Imported `load_json` and replaced the unwrapped `json.loads(raw.strip())` sites with it (sites already in `try/except` were left as-is):

| Context | Function |
|---|---|
| boot order | `get_boot` |
| reset types | `get_reset_types` |
| session | `find_session_uri` |
| managers | `find_managers_resource` (2 sites) |
| power state | power state retrieval |
| job status | `check_schedule_job_status`, `check_job_status` |
| firmware inventory | firmware inventory |
| export job | export job (2 sites) |
| import job | import job |

## Test evidence

- `tests/test_http_client.py`: **39 passed** (including new `test_get_raw_retries_then_succeeds`, `test_get_raw_retries_exhausted_raises`, `test_load_json_valid_returns_parsed`, `test_load_json_raises_on_invalid_json`).
- Targeted main.py-related suites (vendor detection, power, job queue, firmware inventory, SCP, change boot, boot-to, main coverage): all passed.
