### PR TITLE
doc: Add AUR Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
       * [Requirements](#requirements)
       * [Setup](#setup)
          * [Badfish RPM package](#badfish-rpm-package)
+            * [Arch Linux and Derivatives](#arch-linux-and-derivatives)
          * [Badfish Standalone CLI](#badfish-standalone-cli)
          * [Badfish Container](#badfish-container)
          * [Run straight from the repository](#run-straight-from-the-repository)
@@ -156,6 +157,19 @@ Active RPM releases:
 
 > [!NOTE]
 > RHEL and derivatives (Rocky, Alma, etc) should use [containers](#badfish-container) instead due to missing libs/dependencies.
+
+#### Arch Linux and Derivatives
+Arch Linux and derivatives (Manjaro, EndeavourOS, etc) can install Badfish from the [AUR](https://aur.archlinux.org/packages/badfish):
+
+```bash
+yay -S badfish
+```
+
+If using `paru` instead:
+
+```bash
+paru -S badfish
+```
 
 ### Badfish Standalone CLI
 ```bash


### PR DESCRIPTION
## Summary
Adds an "Arch Linux and Derivatives" section under the RPM install method documenting how to install Badfish from the AUR:

```bash
yay -S badfish
```

Also covers `paru` as an alternative AUR helper. Adds a matching entry to the README table of contents.

## Test Plan
- [ ] README renders correctly and the TOC anchor resolves to the new heading.